### PR TITLE
Fix missing / in path concat, caused wrong include and output dirs

### DIFF
--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -11,10 +11,10 @@ set_property(TARGET vizdoom PROPERTY IMPORTED_LOCATION ../../bin/libvizdoom.so)
 find_package(Boost COMPONENTS filesystem thread system date_time chrono regex iostreams REQUIRED)
 find_package(Threads REQUIRED)
 
-set( VIZDOOM_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}../../vizdoom_api_src )
+set( VIZDOOM_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../vizdoom_api_src )
 include_directories( ${VIZDOOM_INCLUDE_DIR} ${Boost_INCLUDE_DIR} )
 
-set( VIZDOOM_EXAMPLES_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}../../bin/examples )
+set( VIZDOOM_EXAMPLES_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../bin/examples )
 
 set( VIZDOOM_LIBS vizdoom
     ${Boost_LIBRARIES}


### PR DESCRIPTION
For me on Fedora 23 C++ examples did not compile due to missing headers. Also example binaries were put to wrong folder and did not start because .so library was not found due to wrong RPATH in ELF binary.