### PR TITLE
Support building libpython on Python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif(COMMAND cmake_policy)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 
-# System dependent settings    
+# System dependent settings
 if(UNIX)
 	set(Boost_USE_STATIC_LIBS OFF)
 	set(Boost_USE_MULTITHREADED ON)
@@ -36,10 +36,10 @@ if(WIN32)
 	add_definitions(-D_WIN32_WINNT=${ver})
 endif()
 
-# Compiler dependent settings     
+# Compiler dependent settings
 if(CMAKE_COMPILER_IS_GNUCXX)
 	add_definitions("-fPIC")
-endif()  
+endif()
 
 if(MSVC)
 	string(REPLACE "/MD " "/MT " CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
@@ -63,13 +63,13 @@ set(VIZDOOM_LIB_INCLUDE_DIR ${VIZDOOM_INCLUDE_DIR} ${VIZDOOM_LIB_SRC_DIR})
 
 include_directories(${VIZDOOM_LIB_INCLUDE_DIR} ${Boost_INCLUDE_DIR})
 
-set(VIZDOOM_LIBS	
+set(VIZDOOM_LIBS
 	${Boost_LIBRARIES}
 	${CMAKE_THREAD_LIBS_INIT} )
-	
+
 if(UNIX AND NOT APPLE)
 	set(VIZDOOM_LIBS ${VIZDOOM_LIBS} rt)
-endif()	
+endif()
 
 file(GLOB VIZDOOM_LIB_SOURCES
 	${VIZDOOM_INCLUDE_DIR}/*.h
@@ -104,36 +104,63 @@ set_target_properties(libvizdoom_static libvizdoom_shared
 
 	add_subdirectory(${VIZDOOM_SRC_DIR}/vizdoom)
 
-#Python binding	
 if(BUILD_PYTHON)
 
 	#set(Boost_USE_DEBUG_PYTHON OFF)
 
-	find_package(PythonInterp 2.7 REQUIRED)
-	find_package(PythonLibs 2.7 REQUIRED)
-	find_package(NumPy REQUIRED)
-	find_package(Boost COMPONENTS python REQUIRED)
+        find_package(PythonInterp 2.7 REQUIRED)
+	# Find the matching Python libs by starting with PYTHON_VERSION_STRING
+	# and stripping off the least significant digit (e.g. 3.4.3 -> 3.4)
+	STRING( REGEX REPLACE "([0-9.]+)\\.[0-9]+" "\\1" python_version ${PYTHON_VERSION_STRING} )
+        find_package(PythonLibs ${python_version} REQUIRED)
+
+	# Find the matching boost python implementation by starting with
+	# PYTHONLIBS_VERSION_STRING (e.g. 3.4.3), stripping off the last part of the
+	# version, and checking for a boost of that version
+	set(version ${PYTHONLIBS_VERSION_STRING})
+	STRING( REGEX REPLACE "[^0-9]" "" boost_py_version ${version} )
+	find_package(Boost COMPONENTS "python-py${boost_py_version}")
+	set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
+
+	while(NOT "${version}" STREQUAL "" AND NOT Boost_PYTHON_FOUND)
+	  STRING( REGEX REPLACE "([0-9.]+).[0-9]+" "\\1" version ${version} )
+
+	  STRING( REGEX REPLACE "[^0-9]" "" boost_py_version ${version} )
+	  find_package(Boost COMPONENTS "python-py${boost_py_version}")
+	  set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
+
+	  STRING( REGEX MATCHALL "([0-9.]+).[0-9]+" has_more_version ${version} )
+	  if("${has_more_version}" STREQUAL "")
+	    break()
+	  endif()
+	endwhile()
+	if(NOT Boost_PYTHON_FOUND)
+	  find_package(Boost COMPONENTS python REQUIRED)
+	endif()
+	set(found_boost_python_library ${Boost_LIBRARIES})
+
+        find_package(NumPy REQUIRED)
 
 	set(VIZDOOM_PYTHON_SRC_DIR ${VIZDOOM_SRC_DIR}/lib_python)
 	set(VIZDOOM_PYTHON_INCLUDE_DIR ${VIZDOOM_INCLUDE_DIR} ${VIZDOOM_PYTHON_SRC_DIR})
 
 	set(VIZDOOM_PYTHON_LIBS
 		${VIZDOOM_LIBS}
-		${Boost_PYTHON_LIBRARY}
+		${found_boost_python_library}
 		${PYTHON_LIBRARIES}
 		${NUMPY_LIBRARIES})
 
 	include_directories(${VIZDOOM_PYTHON_INCLUDE_DIR}
 						${Boost_INCLUDE_DIR}
-						${PYTHON_INCLUDE_DIR}
-						${NUMPY_INCLUDES})  
+						${PYTHON_INCLUDE_DIRS}
+						${NUMPY_INCLUDES})
 
 	set(VIZDOOM_PYTHON_SOURCES
 		${VIZDOOM_PYTHON_SRC_DIR}/ViZDoomGamePython.h
 	    ${VIZDOOM_PYTHON_SRC_DIR}/ViZDoomGamePython.cpp
 		${VIZDOOM_PYTHON_SRC_DIR}/ViZDoomPythonModule.cpp)
-	
-	if(WIN32)	
+
+	if(WIN32)
 		add_definitions(-DBOOST_PYTHON_STATIC_LIB)
 	endif()
 
@@ -173,7 +200,7 @@ if(BUILD_JAVA)
 
 	find_package(Java REQUIRED)
 	find_package(JNI REQUIRED)
-	
+
 	include(UseJava)
 	set(VIZDOOM_JAVA_SRC_DIR ${VIZDOOM_SRC_DIR}/lib_java)
 	set(VIZDOOM_JAVA_CLASSES_DIR ${VIZDOOM_JAVA_SRC_DIR}/java_classes)
@@ -183,10 +210,10 @@ if(BUILD_JAVA)
 		${VIZDOOM_LIBS}
 		${Java_LIBRARIES}
 		${JNI_LIBRARIES})
-		
+
 	if( UNIX )
 		set(JNI_INCLUDE_DIR ${JNI_INCLUDE_DIR}
-			${_JAVA_HOME}/include	
+			${_JAVA_HOME}/include
 			${_JAVA_HOME}/include/linux)
 	endif()
 
@@ -194,20 +221,20 @@ if(BUILD_JAVA)
 		set( JNI_INCLUDE_DIR ${JNI_INCLUDE_DIR}
 			${_JAVA_HOME}/include
 			${_JAVA_HOME}/include/win32 )
-	endif()	
+	endif()
 
 	include_directories(${VIZDOOM_JAVA_INCLUDE_DIR}
 						${Boost_INCLUDE_DIR}
 						${Java_INCLUDE_DIRS}
 						${JNI_INCLUDE_DIR})
 
-	set(VIZDOOM_JAVA_SOURCES 
+	set(VIZDOOM_JAVA_SOURCES
 		${VIZDOOM_JAVA_SRC_DIR}/ViZDoomGameJava.h
 		${VIZDOOM_JAVA_SRC_DIR}/ViZDoomGameJava.cpp)
 
 	add_library(libvizdoom_java SHARED ${VIZDOOM_JAVA_SOURCES})
 	target_link_libraries (libvizdoom_java ${VIZDOOM_JAVA_LIBS} libvizdoom_static)
-	
+
 	set_target_properties(libvizdoom_java
 		PROPERTIES
 		LIBRARY_OUTPUT_DIRECTORY ${VIZDOOM_OUTPUT_DIR}/java
@@ -221,7 +248,7 @@ if(BUILD_JAVA)
 		RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${VIZDOOM_OUTPUT_DIR}/java
 		RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${VIZDOOM_OUTPUT_DIR}/java
 		OUTPUT_NAME vizdoom)
-	
+
 	add_jar(libvizdoom_java_classes
 		${VIZDOOM_JAVA_CLASSES_DIR}/enums/Button.java
 		${VIZDOOM_JAVA_CLASSES_DIR}/enums/GameVariable.java

--- a/cmake_modules/FindNumPy.cmake
+++ b/cmake_modules/FindNumPy.cmake
@@ -38,16 +38,16 @@ if (NOT NUMPY_FOUND)
         set (NUMPY_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
     endif (NOT NUMPY_ROOT_DIR)
 
-    if (NOT PYTHON_FOUND)
+    if (NOT PYTHONINTERP_FOUND)
         find_package (PythonInterp)
-    endif (NOT PYTHON_FOUND)
+    endif (NOT PYTHONINTERP_FOUND)
 
     ##__________________________________________________________________________
     ## Check for the header files
 
     ## Use Python to determine the include directory
     execute_process (
-        COMMAND ${PYTHON_EXECUTABLE} -c import\ numpy\;\ print\ numpy.get_include\(\)\;
+        COMMAND ${PYTHON_EXECUTABLE} -c import\ numpy\;\ print\(numpy.get_include\(\)\)\;
         ERROR_VARIABLE NUMPY_FIND_ERROR
         RESULT_VARIABLE NUMPY_FIND_RESULT
         OUTPUT_VARIABLE NUMPY_FIND_OUTPUT
@@ -78,7 +78,7 @@ if (NOT NUMPY_FOUND)
 
     if (PYTHON_EXECUTABLE)
         execute_process (
-            COMMAND ${PYTHON_EXECUTABLE} -c import\ numpy\;\ print\ numpy.__version__;
+            COMMAND ${PYTHON_EXECUTABLE} -c import\ numpy\;\ print\(numpy.__version__\)\;
             ERROR_VARIABLE NUMPY_API_VERSION_ERROR
             RESULT_VARIABLE NUMPY_API_VERSION_RESULT
             OUTPUT_VARIABLE NUMPY_API_VERSION

--- a/src/lib_python/ViZDoomGamePython.cpp
+++ b/src/lib_python/ViZDoomGamePython.cpp
@@ -30,9 +30,20 @@ namespace vizdoom {
 
     #define PY_NONE object()
 
-    DoomGamePython::DoomGamePython() {
+    #if PY_MAJOR_VERSION >= 3
+    int
+    #else
+    void
+    #endif
+    init_numpy()
+    {
         boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
-        import_array(); 
+        import_array();
+    }
+
+
+    DoomGamePython::DoomGamePython() {
+        init_numpy();
     }
 
     bool DoomGamePython::init() {
@@ -42,7 +53,7 @@ namespace vizdoom {
             int channels = this->getScreenChannels();
             int x = this->getScreenWidth();
             int y = this->getScreenHeight();
-            
+
             switch(this->getScreenFormat()) {
                 case CRCGCB:
                 case CRCGCBDB:
@@ -82,7 +93,7 @@ namespace vizdoom {
     }
 
     double DoomGamePython::makeAction(boost::python::list const &action, unsigned int tics) {
-        return DoomGame::makeAction(DoomGamePython::pyListToIntVector(action), tics);   
+        return DoomGame::makeAction(DoomGamePython::pyListToIntVector(action), tics);
     }
 
     GameStatePython DoomGamePython::getState() {
@@ -112,7 +123,7 @@ namespace vizdoom {
         boost::python::list res;
         for (std::vector<int>::iterator it = DoomGame::lastAction.begin(); it!=DoomGame::lastAction.end(); ++it)
         {
-            res.append(*it); 
+            res.append(*it);
         }
         return res;
     }

--- a/src/lib_python/ViZDoomPythonModule.cpp
+++ b/src/lib_python/ViZDoomPythonModule.cpp
@@ -80,14 +80,24 @@ void (DoomGamePython::*advanceAction3)(unsigned int, bool, bool) = &DoomGamePyth
 double (DoomGamePython::*makeAction1)(bp::list const &) = &DoomGamePython::makeAction;
 double (DoomGamePython::*makeAction2)(bp::list const &, unsigned int) = &DoomGamePython::makeAction;
 
+#if PY_MAJOR_VERSION >= 3
+int
+#else
+void
+#endif
+init_numpy()
+{
+    bp::numeric::array::set_module_and_type("numpy", "ndarray");
+    import_array();
+}
+
 BOOST_PYTHON_MODULE(vizdoom)
 {
     using namespace boost::python;
 
     Py_Initialize();
-    bp::numeric::array::set_module_and_type("numpy", "ndarray");
-    import_array();
-    
+    init_numpy();
+
     /* exceptions */
 
 #define EXCEPTION_TO_PYT(n) type ## n = createExceptionClass(#n); \
@@ -101,7 +111,7 @@ bp::register_exception_translator< n >(&translate ## n );
     /* typeMyException = createExceptionClass("myException");
      * bp::register_exception_translator<myException>(&translate);
      */
-        
+
     EXCEPTION_TO_PYT(ViZDoomMismatchedVersionException)
     EXCEPTION_TO_PYT(ViZDoomUnexpectedExitException)
     EXCEPTION_TO_PYT(ViZDoomIsNotRunningException)
@@ -316,23 +326,23 @@ bp::register_exception_translator< n >(&translate ## n );
         .def("advance_action", advanceAction1)
         .def("advance_action", advanceAction2)
         .def("advance_action", advanceAction3)
-        
+
         .def("get_state", &DoomGamePython::getState)
-    
+
         .def("get_game_variable", &DoomGamePython::getGameVariable)
         .def("get_game_screen", &DoomGamePython::getGameScreen)
 
         .def("get_living_reward", &DoomGamePython::getLivingReward)
         .def("set_living_reward", &DoomGamePython::setLivingReward)
-        
+
         .def("get_death_penalty", &DoomGamePython::getDeathPenalty)
         .def("set_death_penalty", &DoomGamePython::setDeathPenalty)
-        
+
         .def("get_last_reward", &DoomGamePython::getLastReward)
         .def("get_total_reward", &DoomGamePython::getTotalReward)
-        
+
         .def("get_last_action", &DoomGamePython::getLastAction)
-        
+
         .def("add_available_game_variable", &DoomGamePython::addAvailableGameVariable)
         .def("clear_available_game_variables", &DoomGamePython::clearAvailableGameVariables)
         .def("get_available_game_variables_size", &DoomGamePython::getAvailableGameVariablesSize)
@@ -371,7 +381,7 @@ bp::register_exception_translator< n >(&translate ## n );
 
         .def("set_console_enabled",&DoomGamePython::setConsoleEnabled)
         .def("set_sound_enabled",&DoomGamePython::setSoundEnabled)
-        
+
         .def("set_screen_resolution", &DoomGamePython::setScreenResolution)
         .def("set_screen_format", &DoomGamePython::setScreenFormat)
         .def("set_render_hud", &DoomGamePython::setRenderHud)


### PR DESCRIPTION
Significant changes include:
- Guard calls to import_array() in an initialization function (see https://mail.scipy.org/pipermail/numpy-discussion/2010-December/054345.html)
- Modify CMakeLists.txt to find the right version of libpython and libboost-python{3.x}
- Fix FindNumPy.cmake to use Python3 compatible print syntax