### PR TITLE
Fix variable typo in python examples

### DIFF
--- a/examples/python/learning.py
+++ b/examples/python/learning.py
@@ -165,7 +165,7 @@ def perform_learning_step(epoch):
         else:
             return end_eps
 
-    s1 = preprocess(game.get_state().image_buffer)
+    s1 = preprocess(game.get_state().screen_buffer)
 
     # With probability eps make a random action.
     eps = exploration_rate(epoch)
@@ -177,7 +177,7 @@ def perform_learning_step(epoch):
     reward = game.make_action(actions[a], frame_repeat)
 
     isterminal = game.is_episode_finished()
-    s2 = preprocess(game.get_state().image_buffer) if not isterminal else None
+    s2 = preprocess(game.get_state().screen_buffer) if not isterminal else None
 
     learn_from_transition(s1, a, s2, isterminal, reward)
 
@@ -237,7 +237,7 @@ for epoch in range(epochs):
     for test_episode in trange(test_episodes_per_epoch):
         game.new_episode()
         while not game.is_episode_finished():
-            state = preprocess(game.get_state().image_buffer)
+            state = preprocess(game.get_state().screen_buffer)
             best_action_index = get_best_action(state)
 
             game.make_action(actions[best_action_index], frame_repeat)
@@ -270,7 +270,7 @@ episodes_to_watch = 10
 for i in range(episodes_to_watch):
     game.new_episode()
     while not game.is_episode_finished():
-        state = preprocess(game.get_state().image_buffer)
+        state = preprocess(game.get_state().screen_buffer)
         best_action_index = get_best_action(state)
 
         # Instead of make_action(a, frame_repeat) in order to make the animation smooth

--- a/examples/python/seed.py
+++ b/examples/python/seed.py
@@ -2,16 +2,16 @@
 
 #####################################################################
 # This script presents how to run deterministic episodes by setting
-# seed. After setting the seed every episode will look the same (if 
+# seed. After setting the seed every episode will look the same (if
 # agent will behave deterministicly of course).
 # Configuration is loaded from "../../examples/config/<SCENARIO_NAME>.cfg" file.
-# <episodes> number of episodes are played. 
+# <episodes> number of episodes are played.
 # Random combination of buttons is chosen for every action.
-# 
+#
 # Game variables from state and last reward are printed.
 #
 # To see the scenario description go to "../../scenarios/README.md"
-# 
+#
 #####################################################################
 from __future__ import print_function
 
@@ -62,7 +62,7 @@ for i in range(episodes):
     while not game.is_episode_finished():
         # Gets the state and possibly to something with it
         s = game.get_state()
-        img = s.image_buffer
+        img = s.screen_buffer
         misc = s.game_variables
 
         # Check which action you chose!

--- a/examples/python/shaping.py
+++ b/examples/python/shaping.py
@@ -3,15 +3,15 @@
 #####################################################################
 # This script presents how to make use of game variables to implement
 # shaping using health_guided.wad scenario
-# Health_guided scenario is just like health_gathering 
+# Health_guided scenario is just like health_gathering
 # (see "../../scenarios/README.md") but for each collected medkit global
 # variable number 1 in acs script (coresponding to USER1) is increased
 # by 100.0. It is not considered a part of reward but will possibly
 # reduce learning time.
-# <episodes> number of episodes are played. 
+# <episodes> number of episodes are played.
 # Random combination of buttons is chosen for every action.
 # Game variables from state and last reward are printed.
-# 
+#
 #####################################################################
 from __future__ import print_function
 
@@ -50,7 +50,7 @@ for i in range(episodes):
 
         # Gets the state and possibly to something with it
         s = game.get_state()
-        img = s.image_buffer
+        img = s.screen_buffer
         misc = s.game_variables
 
         # Makes a random action and save the reward.


### PR DESCRIPTION
Changed “image_buffer” to “screen_buffer” in some python examples, (hopefully they refer to the same thing, any rate seems to be working with the rename)